### PR TITLE
Add dynamic preferences and add functionally with spoon api

### DIFF
--- a/prestopantry_app/backends/spoonacular_api.py
+++ b/prestopantry_app/backends/spoonacular_api.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 import requests
+from dynamic_preferences.registries import global_preferences_registry
 
 SPOON_API = settings.SPOON_API_KEY
 
@@ -14,17 +15,18 @@ url2 = "https://spoonacular-recipe-food-nutrition-v1.p.rapidapi.com/recipes/find
 
 
 class SpoonacularAPI():
+    global_preferences = global_preferences_registry.manager()
 
-    def ingredient_request(request, data):
-        response = requests.request(request, url1, data=str(data), headers=headers)
-        return response
+    def ingredient_request(cls, request, data):
+        if cls.global_preferences['spoonacular_api_enabled']:
+            return requests.request(request, url1, data=str(data), headers=headers)
 
-    def recipe_request(request, params):
-        response = requests.request(request, url2, params=params, headers=headers)
-        return response
+    def recipe_request(cls, request, params):
+        if cls.global_preferences['spoonacular_api_enabled']:
+            return requests.request(request, url2, params=params, headers=headers)
         
 
-
+    @staticmethod
     def harvest_ingredients(json_file):
         ingredient_name = json_file[0]['originalName']
         image = json_file[0]['ingredientImage']
@@ -48,6 +50,7 @@ class SpoonacularAPI():
 
         return ingredient_payload
 
+    @staticmethod
     def harvest_recipe_per_ingredients(json_file):
 
         payload = []

--- a/prestopantry_app/dynamic_preferences_registry.py
+++ b/prestopantry_app/dynamic_preferences_registry.py
@@ -1,0 +1,14 @@
+from dynamic_preferences.types import BooleanPreference
+from dynamic_preferences.registries import global_preferences_registry
+
+@global_preferences_registry.register
+class SpoonacularApiEnabled(BooleanPreference):
+    name = 'spoonacular_api_enabled'
+    default = True
+    help_text = 'Enable/Disable Spoonacular API'
+
+@global_preferences_registry.register
+class GoogleCustomSearchApiEnabled(BooleanPreference):
+    name = 'google_custom_search_api_enabled'
+    default = True
+    help_text = 'Enable/Disable Google Custom Search API'

--- a/prestopantry_app/templates/search_pantry_ingredients.html
+++ b/prestopantry_app/templates/search_pantry_ingredients.html
@@ -29,12 +29,13 @@
 
 
 
-    {% if ingredient_name %}
 
     {% comment %}
     <h5 class="card-title">{{ingredient_name}}</h5>
     {% endcomment %}
     
+    <h3 class="text-center text-white">{{error}}</h3>
+
     <div class="row ps-4">
         {% for item in ingredient_info %}
         <div class=" col-sm-2 col-md-3 col-lg-3 g-4">
@@ -115,9 +116,6 @@
 
     {% endcomment %}
         
-{% else %}
-<h3 class="text-center text-white">No Searches found...</h3>
-{% endif %}
 
 </div>
 

--- a/prestopantry_app/tests/view_tests/test_pantry_ingredients_views.py
+++ b/prestopantry_app/tests/view_tests/test_pantry_ingredients_views.py
@@ -38,7 +38,6 @@ class PantryIngredientsViewTest(TestCase):
             response = self.client.post(reverse('search-pantry-ingredients'), {'ingredient_button': '', 'ingredient_name': 'test'})
             mock_request.assert_called_once()
             self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, 'Search Error')
 
         # test search page
         response = self.client.get(reverse('search-pantry-ingredients'))

--- a/prestopantry_app/tests/view_tests/test_pantry_ingredients_views.py
+++ b/prestopantry_app/tests/view_tests/test_pantry_ingredients_views.py
@@ -1,12 +1,15 @@
 from django.test import TestCase
 from django.urls import reverse
+from dynamic_preferences.registries import global_preferences_registry
 from prestopantry_app.models.users import User
 from prestopantry_app.models.user_ingredients import UserIngredient
+from unittest.mock import patch
 
 
 class PantryIngredientsViewTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user('goldmember','drevil@gmail.com','ilovegold')
+        self.global_preferences = global_preferences_registry.manager()
     
     def test_my_pantry_view(self):
         self.client.force_login(self.user)
@@ -22,12 +25,26 @@ class PantryIngredientsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'search_pantry_ingredients.html')
 
-        # test search
-        data = {'q': '88'}
-        response = self.client.get(reverse('search-pantry-ingredients'), data)
-        self.assertContains(response, 'No Searches found...')
+        with patch('prestopantry_app.backends.spoonacular_api.requests.request') as mock_request:
+            # Test when Spoon API is disabled
+            self.global_preferences['spoonacular_api_enabled'] = False
+            response = self.client.post(reverse('search-pantry-ingredients'), {'ingredient_button': '', 'ingredient_name': 'test'})
+            mock_request.assert_not_called()
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, 'Search Error')
 
-        # # test add
+            # Test when Spoon API is enabled
+            self.global_preferences['spoonacular_api_enabled'] = True
+            response = self.client.post(reverse('search-pantry-ingredients'), {'ingredient_button': '', 'ingredient_name': 'test'})
+            mock_request.assert_called_once()
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, 'Search Error')
+
+        # test search page
+        response = self.client.get(reverse('search-pantry-ingredients'))
+        self.assertContains(response, 'No results found, please check spelling and try again')
+
+        # test add
         session = self.client.session
         session.update({'ingredient_search_results': {'ingredient_info': [['Torkelson Cheese Co. Brick Cheese Wisconsin', 406181, 123344564378]]}})
         session.save()

--- a/prestopantry_app/views/pantry_ingredients_views.py
+++ b/prestopantry_app/views/pantry_ingredients_views.py
@@ -3,10 +3,9 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from prestopantry_app.models.user_ingredients import UserIngredient
 
-
 @login_required(login_url='login')
 def search_by_ingredient(request):
-    json_scraper = SpoonacularAPI
+    json_scraper = SpoonacularAPI()
     if request.method == 'POST' and 'ingredient_button' in request.POST:
 
         payload = {
@@ -14,13 +13,16 @@ def search_by_ingredient(request):
           'servings': 1
           }
 
-        response = json_scraper.ingredient_request("POST", data=str(payload))
-        ingredient_json = response.json()
-        if response.status_code == 200 and ingredient_json != []:
-            context = json_scraper.harvest_ingredients(ingredient_json)
-            request.session['ingredient_search_results'] = context
+        response = json_scraper.ingredient_request(request="POST", data=str(payload))
+        if response and response.status_code == 200:
+            ingredient_json = response.json()
+            if ingredient_json != []:
+                context = json_scraper.harvest_ingredients(ingredient_json)
+                request.session['ingredient_search_results'] = context
 
-            return render(request, 'search_pantry_ingredients.html', context)
+                return render(request, 'search_pantry_ingredients.html', context)
+        else:
+            return render(request, 'search_pantry_ingredients.html', {'error': 'Search Error'})
 
     elif request.method == 'POST' and 'ingredient_per_recipe_button' in request.POST:
 
@@ -55,7 +57,7 @@ def search_by_ingredient(request):
 
         return render(request, 'search_pantry_ingredients.html', request.session['ingredient_search_results'])
 
-    return render(request, 'search_pantry_ingredients.html', {})
+    return render(request, 'search_pantry_ingredients.html', {'error': 'No results found, please check spelling and try again'})
 
 @login_required(login_url='login')
 def display_pantry(request):

--- a/prestopantry_project/settings.py
+++ b/prestopantry_project/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'dynamic_preferences',
     'social_django',
     'storages',
     
@@ -77,6 +78,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'dynamic_preferences.processors.global_preferences',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
             ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 crispy-bootstrap5==0.6
 Django==4.0.2
+django-dynamic-preferences==1.12.0
 django-storages==1.12.3
 idna==3.3
 jmespath==0.10.0


### PR DESCRIPTION
Adds a model within admin called `Dynamic Preferences` that has global and user preferences (only utilizing global at this time) which can be used to enable/disable API functionally within our app. At this time it has `spoonacular_api_enabled` and `google_custom_search_api_enabled`, and are set to true by default. `spoonacular_api_enabled` preference is implemented and fully functional. 