### PR TITLE
Upgrading Django for Security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ botocore==1.24.8
 certifi==2021.10.8
 charset-normalizer==2.0.12
 click>=7.0
-Django>=4.0.4
+Django==4.0.4
 django-dynamic-preferences==1.12.0
 django-storages==1.12.3
 Google-Images-Search==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ botocore==1.24.8
 certifi==2021.10.8
 charset-normalizer==2.0.12
 click>=7.0
-Django==4.0.2
+Django>=4.0.4
 django-dynamic-preferences==1.12.0
 django-storages==1.12.3
 Google-Images-Search==1.4.2


### PR DESCRIPTION
Dependabot alert identified security vulnerability present in Django 4.0.2. Forcing Requirements to go to 4.0.4 is the recommended solution.