### PR TITLE
Remove redundant psycopg2 to fix aws beanstalk

### DIFF
--- a/prestopantry_project/settings/production.py
+++ b/prestopantry_project/settings/production.py
@@ -15,4 +15,4 @@ from .base import *
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = ['PresotPantryenv.eba-ed5zcunn.us-east-1.elasticbeanstalk.com']
+ALLOWED_HOSTS = ['PrestoPantryEnv.eba-f7pbnqnf.us-east-1.elasticbeanstalk.com']

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,7 @@ ggshield==1.10.8
 idna==3.3
 jmespath==0.10.0
 pre-commit==2.18.1
-psycopg2==2.9.3
-psycopg2-binary==2.9.3
+psycopg2-binary==2.8.5
 pygitguardian==1.3.1
 python-dateutil==2.8.2
 requests==2.27.1


### PR DESCRIPTION
Remove redundant psycopg2 to fix aws beanstalk